### PR TITLE
setup: docker env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/docker-existing-dockerfile
+{
+	"name": "cs143",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../Dockerfile",
+
+	"containerEnv": {
+		"PATH": "${localEnv:PATH}:/usr/class/cs143/cool/bin"
+	},
+
+	"workspaceMount": "source=${localWorkspaceFolder},target=/usr/class/cs143/cool,type=bind",
+	"workspaceFolder": "/usr/class/cs143/cool"
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+RUN dpkg --add-architecture i386
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y flex bison build-essential csh libxaw7-dev libc6:i386
+
+# Cleanup
+RUN apt-get autoremove && apt-get autoclean
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ The project depends on the reference COOL project and various tools. This setup 
 3. Run **compile-compiler.sh** in the root of this repository
 	* This script should build all compiler stages separately and link them
 	* You should be able to run compiler using ./coolc in the root of this repository
+
+### Docker
+**This setup need [vscode](https://code.visualstudio.com/) and [remote-containers](https://code.visualstudio.com/docs/remote/containers-tutorial) plugin**
+#### Setup project
+1. Clone this repository, open repository root directory in `vscode`
+2. Open `Command Palette`, choose `Open Folder in Container...`
+	* First time it will build a container that contain all project tools and environment
+	* vscode will use that container as development environment and mount workspace folder at `/use/class/cs143/cool`, `PATH` enviroment variable is already set for you
+
 ## Potential improvements
 * Refactor complete project
 	* Since this project was built in several assignments, due to the skeleton project build process it was hard to reuse some logic (like traversing the class inheritance graph) so the complete implementation of this compiler consists of only 5 files mentioned in [project structure section](#project-structure) which sometimes duplicate logic from previous steps.


### PR DESCRIPTION
Install a VM or Ubuntu is too heavy to set up this course dev environment.
Use [vscode](https://code.visualstudio.com/) and [remote-containers](https://code.visualstudio.com/docs/remote/containers-tutorial) plugin as cs143 develop environment is light that need only seconds to setup.